### PR TITLE
Flip default behavior of whether to accept hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Options
 
  * `identity`: `IO.device` providing the ssh private key (required)
  * `known_hosts`: `IO.device` providing the known hosts list. If providing a File IO, it should have been opened in `:write` mode (required)
- * `accept_hosts`: `boolean` silently accept and add new hosts to the known hosts. By default only known hosts will be accepted.
+ * `silently_accept_hosts`: `boolean` silently accept and add new hosts to the known hosts. By default only known hosts will be accepted.
 
 `SSHClientKeyApi` is meant to primarily be used via the convenience function
 `with_config`:
@@ -33,7 +33,7 @@ Options
 ```elixir
   key = File.open!("path/to/keyfile.pub")
   known_hosts = File.open!("path/to/known_hosts")
-  cb = SSHClientKeyAPI.with_options(identity: key, known_hosts: known_hosts, accept_hosts: false)
+  cb = SSHClientKeyAPI.with_options(identity: key, known_hosts: known_hosts, silently_accept_hosts: true)
 ```
 
 The result can then be passed as an option when creating an SSH connection.

--- a/test/ssh_client_key_api_test.exs
+++ b/test/ssh_client_key_api_test.exs
@@ -57,22 +57,22 @@ github.com,192.30.252.128 ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9
     }
   end
 
-  test "add_host_key writes an entry to known hosts if accept_hosts is true", %{known_hosts: known_hosts} do
+  test "add_host_key writes an entry to known hosts if silently_accept_hosts is true", %{known_hosts: known_hosts} do
     SSHClientKeyAPI.add_host_key(
       "example.com",
       @host_key,
-      [key_cb_private: [accept_hosts: true, known_hosts: known_hosts, known_hosts_data: IO.binread(known_hosts, :all)]]
+      [key_cb_private: [silently_accept_hosts: true, known_hosts: known_hosts, known_hosts_data: IO.binread(known_hosts, :all)]]
       )
     :file.position(known_hosts, :bof)
     result = IO.binread(known_hosts, :all)
     assert result =~ "example.com"
   end
 
-  test "add_host_key returns an error if accept_hosts is false", %{known_hosts: known_hosts} do
+  test "add_host_key returns an error if silently_accept_hosts is false", %{known_hosts: known_hosts} do
     result = SSHClientKeyAPI.add_host_key(
       "example.com",
       @host_key,
-      [key_cb_private: [accept_hosts: false, known_hosts: known_hosts, known_hosts_data: IO.binread(known_hosts, :all)]])
+      [key_cb_private: [silently_accept_hosts: false, known_hosts: known_hosts, known_hosts_data: IO.binread(known_hosts, :all)]])
     assert {:error, _message} = result
   end
 
@@ -81,7 +81,7 @@ github.com,192.30.252.128 ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9
       @host_key,
       'github.com',
       :"ssh-dsa",
-      [key_cb_private: [accept_hosts: false, known_hosts: known_hosts, known_hosts_data: IO.binread(known_hosts, :all)]])
+      [key_cb_private: [silently_accept_hosts: false, known_hosts: known_hosts, known_hosts_data: IO.binread(known_hosts, :all)]])
     assert result
   end
 
@@ -90,7 +90,7 @@ github.com,192.30.252.128 ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9
       @host_key,
       'other.com',
       :"ssh-dsa",
-      [key_cb_private: [accept_hosts: false, known_hosts: known_hosts, known_hosts_data: IO.binread(known_hosts, :all)]])
+      [key_cb_private: [silently_accept_hosts: false, known_hosts: known_hosts, known_hosts_data: IO.binread(known_hosts, :all)]])
     refute result
   end
 


### PR DESCRIPTION
Also rename option to `silently_accept_hosts` to be consistent with Erlang SSH options

Closes #1 