### PR TITLE
 Switch supported key algorithm list to match OTP.

### DIFF
--- a/lib/ssh_client_key_api.ex
+++ b/lib/ssh_client_key_api.ex
@@ -1,7 +1,7 @@
 defmodule SSHClientKeyAPI do
 
   @behaviour :ssh_client_key_api
-  @key_algorithms ~w(ssh-rsa ssh-dss ecdsa-sha2-nistp256 ecdsa-sha2-nistp384 ecdsa-sha2-nistp521)a
+  @key_algorithms :ssh.default_algorithms()[:public_key]
 
   @moduledoc ~S"""
 

--- a/lib/ssh_client_key_api.ex
+++ b/lib/ssh_client_key_api.ex
@@ -1,7 +1,7 @@
 defmodule SSHClientKeyAPI do
 
   @behaviour :ssh_client_key_api
-  @key_algorithms ~w(ssh-rsa ssh-dsa ecdsa-sha2-nistp256 ecdsa-sha2-nistp384 ecdsa-sha2-nistp521)a
+  @key_algorithms ~w(ssh-rsa ssh-dss ecdsa-sha2-nistp256 ecdsa-sha2-nistp384 ecdsa-sha2-nistp521)a
 
   @moduledoc ~S"""
 

--- a/test/ssh_client_key_api_test.exs
+++ b/test/ssh_client_key_api_test.exs
@@ -80,7 +80,7 @@ github.com,192.30.252.128 ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9
     result = SSHClientKeyAPI.is_host_key(
       @host_key,
       'github.com',
-      :"ssh-dsa",
+      :"ssh-dss",
       [key_cb_private: [silently_accept_hosts: false, known_hosts: known_hosts, known_hosts_data: IO.binread(known_hosts, :all)]])
     assert result
   end
@@ -89,14 +89,14 @@ github.com,192.30.252.128 ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9
     result = SSHClientKeyAPI.is_host_key(
       @host_key,
       'other.com',
-      :"ssh-dsa",
+      :"ssh-dss",
       [key_cb_private: [silently_accept_hosts: false, known_hosts: known_hosts, known_hosts_data: IO.binread(known_hosts, :all)]])
     refute result
   end
 
   test "user key returns the contents of the key option", %{key: key} do
     result = SSHClientKeyAPI.user_key(
-      :"ssh-dsa",
+      :"ssh-dss",
       [key_cb_private: [identity: key, identity_data: IO.binread(key, :all)]]
     )
     assert result == {:ok, @decoded_pem}


### PR DESCRIPTION
Removes a bogus algorithm and corrects the real world issues with `ssh-dss`.