### PR TITLE
Throw exceptions instead of returning errors

### DIFF
--- a/lib/ssh_client_key_api/key_error.ex
+++ b/lib/ssh_client_key_api/key_error.ex
@@ -1,0 +1,18 @@
+defmodule SSHClientKeyAPI.KeyError do
+  defexception [:reason, :algorithm]
+
+  def exception({reason, algo}), do: %__MODULE__{reason: reason, algorithm: algo}
+
+  def exception(reason), do: %__MODULE__{reason: reason}
+
+  def message(%__MODULE__{reason: :unsupported_algorithm}), do: "key algorithm is not supported"
+
+  def message(%__MODULE__{reason: :passphrase_required}),
+    do: "passphrase required for protected key"
+
+  def message(%__MODULE__{reason: :incorrect_passphrase}),
+    do: "passphrase invalid for protected key"
+
+  def message(%__MODULE__{reason: :unsupported_algorithm, algorithm: algo}),
+    do: "key algorithm is not supported: #{algo}"
+end


### PR DESCRIPTION
Resolves #12 

Returning error tuples isn't enough to bubble up a useful error to the user

Existing error when trying to use ed25519:
```elixir
iex> conn = SSHKit.SSH.connect("localdev", user: "radams", key_cb: ed25519_cb)
{:error,
 {:function_clause,
  [
    {SSHClientKeyAPI, :decode_pem_entry, [nil, 'foobar'],
     [file: 'lib/ssh_client_key_api.ex', line: 111]},
    {:ssh_auth, :get_public_key, 2, [file: 'ssh_auth.erl', line: 145]},
    {:ssh_connection_handler, :is_usable_user_pubkey, 2,
     [file: 'ssh_connection_handler.erl', line: 1769]},
    {:ssh_connection_handler, :"-init_ssh_record/4-lc$^0/1-0-", 2,
     [file: 'ssh_connection_handler.erl', line: 477]},
    {:ssh_connection_handler, :init_ssh_record, 4,
     [file: 'ssh_connection_handler.erl', line: 476]},
    {:ssh_connection_handler, :init, 1,
     [file: 'ssh_connection_handler.erl', line: 412]},
    {:ssh_connection_handler, :init_connection_handler, 3,
     [file: 'ssh_connection_handler.erl', line: 374]},
    {:proc_lib, :init_p_do_apply, 3, [file: 'proc_lib.erl', line: 247]}
  ]}}
```

Becomes:
```elixir
iex> conn = SSHKit.SSH.connect("localdev", user: "radams", key_cb: ed25519_cb)
{:error,
 {%SSHClientKeyAPI.KeyError{algorithm: :unknown, reason: :unsupported_algorithm},
  [
    {SSHClientKeyAPI, :decode_pem_entry, 2,
     [file: 'lib/ssh_client_key_api.ex', line: 115]},
    {:ssh_auth, :get_public_key, 2, [file: 'ssh_auth.erl', line: 145]},
    {:ssh_connection_handler, :is_usable_user_pubkey, 2,
     [file: 'ssh_connection_handler.erl', line: 1769]},
    {:ssh_connection_handler, :"-init_ssh_record/4-lc$^0/1-0-", 2,
     [file: 'ssh_connection_handler.erl', line: 477]},
    {:ssh_connection_handler, :init_ssh_record, 4,
     [file: 'ssh_connection_handler.erl', line: 476]},
    {:ssh_connection_handler, :init, 1,
     [file: 'ssh_connection_handler.erl', line: 412]},
    {:ssh_connection_handler, :init_connection_handler, 3,
     [file: 'ssh_connection_handler.erl', line: 374]},
    {:proc_lib, :init_p_do_apply, 3, [file: 'proc_lib.erl', line: 247]}
  ]}}
```