### PR TITLE
Disable raise inside rescue warning

### DIFF
--- a/lib/ssh_client_key_api.ex
+++ b/lib/ssh_client_key_api.ex
@@ -122,6 +122,7 @@ defmodule SSHClientKeyAPI do
   defp decode_pem_entry({_type, _data, {alg, _}} = entry, phrase) do
     {:ok, :public_key.pem_entry_decode(entry, phrase)}
   rescue
+    # credo:disable-for-next-line Credo.Check.Warning.RaiseInsideRescue
     _e in MatchError -> raise KeyError, {:incorrect_passphrase, alg}
   end
 


### PR DESCRIPTION
In this case, the stacktrace isn’t useful to preserve via `reraise`